### PR TITLE
fix ElectrodeGrid issues, make tests pass; build Argus II from ElectrodeGrid

### DIFF
--- a/pulse2percept/implants/__init__.py
+++ b/pulse2percept/implants/__init__.py
@@ -4,6 +4,7 @@ The `pulse2percept.implants` module provides a number of visual prostheses.
 from .base import (DiskElectrode,
                    Electrode,
                    ElectrodeArray,
+                   ElectrodeGrid,
                    PointSource,
                    ProsthesisSystem)
 from .argus import ArgusI, ArgusII
@@ -16,6 +17,7 @@ __all__ = [
     'DiskElectrode',
     'Electrode',
     'ElectrodeArray',
+    'ElectrodeGrid',
     'PointSource',
     'ProsthesisSystem'
 ]

--- a/pulse2percept/implants/argus.py
+++ b/pulse2percept/implants/argus.py
@@ -1,5 +1,7 @@
 import numpy as np
-from .base import DiskElectrode, ElectrodeArray, ProsthesisSystem
+import collections as coll
+from .base import (DiskElectrode, ElectrodeArray, ElectrodeGrid,
+                   ProsthesisSystem)
 
 
 class ArgusI(ProsthesisSystem):
@@ -200,66 +202,38 @@ class ArgusII(ProsthesisSystem):
         >>> my_electrode = argus['E7']
 
         """
-        # Electrodes are 200um in diameter
-        r_arr = np.ones(60) * 100.0
+        # Argus II is a 6x10 grid of electrodes with 200um in diamater, spaced
+        # 525um apart, with rows labeled alphabetically and columsn
+        # numerically:
+        shape = (6, 10)
+        r = 100.0
+        spacing = 525.0
+        names = ('A', '1')
+        self.earray = ElectrodeGrid(shape, x=x, y=y, z=z, rot=rot, r=r,
+                                    spacing=spacing, names=names)
 
-        # Set left/right eye
-        self.eye = eye
-
-        # Standard ArgusII names: A1, A2, ..., A10, B1, ..., F10
-        names = [chr(i) + str(j) for i in range(65, 71) for j in range(1,
-                                                                       11)]
-
-        # if self.eye == 'RE':
-        #    names = [chr(i) + str(j) for i in range(65, 71)
-        #             for j in range(1, 11)]
-        # else:
-        #    names = [chr(i) + str(j) for i in range(65, 71)
-        #             for j in range(11, 1, -1)]
-
-        if isinstance(z, (list, np.ndarray)):
-            z_arr = np.asarray(z).flatten()
-            if z_arr.size != len(r_arr):
-                e_s = "If `h` is a list, it must have 60 entries."
-                raise ValueError(e_s)
-        else:
-            # All electrodes have the same height
-            z_arr = np.ones_like(r_arr) * z
-
-        # Equally spaced electrodes: n_rows x n_cols = 60
-        e_spacing = 525  # um
-        n_cols = 10  # number of electrodes horizontally
-        n_rows = 6  # number of electrodes vertically
-        x_arr = np.arange(n_cols) * e_spacing - (n_cols / 2 - 0.5) * e_spacing
-        if self.eye == 'LE':
-            # Left eye: Need to invert x coordinates and rotation angle
-            x_arr = x_arr[::-1]
-
-        y_arr = np.arange(n_rows) * e_spacing - (n_rows / 2 - 0.5) * e_spacing
-        x_arr, y_arr = np.meshgrid(x_arr, y_arr, sparse=False)
-
-        # Rotation matrix
-        rotmat = np.array([np.cos(rot), -np.sin(rot),
-                           np.sin(rot), np.cos(rot)]).reshape((2, 2))
-
-        # Set the x, y location of the tack
-        if self.eye == 'RE':
-            self.tack = np.matmul(rotmat, [-(n_cols / 2 + 0.5) * e_spacing, 0])
-        else:
-            self.tack = np.matmul(rotmat, [(n_cols / 2 + 0.5) * e_spacing, 0])
-        self.tack = tuple(self.tack + [x, y])
-
-        # Rotate the array
-        xy = np.vstack((x_arr.flatten(), y_arr.flatten()))
-        xy = np.matmul(rotmat, xy)
-        x_arr = xy[0, :]
-        y_arr = xy[1, :]
-
-        # Apply offset
-        x_arr += x
-        y_arr += y
-
-        self.earray = ElectrodeArray([])
-        for x, y, z, r, name in zip(x_arr, y_arr, z_arr, r_arr, names):
-            self.earray.add_electrode(name, DiskElectrode(x, y, z, r))
+        # Set stimulus if available:
         self.stim = stim
+
+        # Set left/right eye:
+        if not isinstance(eye, str):
+            raise TypeError("'eye' must be a string, either 'LE' or 'RE'.")
+        if eye != 'LE' and eye != 'RE':
+            raise ValueError("'eye' must be either 'LE' or 'RE'.")
+        self.eye = eye
+        # Unfortunately, in the left eye the labeling of columns is reversed...
+        if eye == 'LE':
+            # FIXME: Would be better to have more flexibility in the naming
+            # convention. This is a quick-and-dirty fix:
+            names = list(self.earray.keys())
+            objects = list(self.earray.values())
+            names = np.array(names).reshape(self.earray.shape)
+            # Reverse column names:
+            for row in range(self.earray.shape[0]):
+                names[row] = names[row][::-1]
+            # Build a new ordered dict:
+            electrodes = coll.OrderedDict([])
+            for name, obj in zip(names.ravel(), objects):
+                electrodes.update({name: obj})
+            # Assign the new ordered dict to earray:
+            self.earray.electrodes = electrodes

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -15,11 +15,11 @@ class Electrode(PrettyPrint):
         Abstract base class for all electrodes.
         """
         if isinstance(x, (coll.Sequence, np.ndarray)):
-            raise TypeError("x must be a scalar.")
+            raise TypeError("x must be a scalar, not %s." % (type(x)))
         if isinstance(y, (coll.Sequence, np.ndarray)):
-            raise TypeError("y must be a scalar.")
+            raise TypeError("y must be a scalar, not %s." % type(y))
         if isinstance(z, (coll.Sequence, np.ndarray)):
-            raise TypeError("z must be a scalar.")
+            raise TypeError("z must be a scalar, not %s." % type(z))
         self.x = x
         self.y = y
         self.z = z
@@ -267,112 +267,130 @@ class ProsthesisSystem(PrettyPrint):
 # inherit electrode array
 class ElectrodeGrid(ElectrodeArray):
 
-    def __init__(self, cols=1, rows=1, x=0, y=0, z=0, rot=0, r=10, spacing=0,
-                 name_cols='1', name_rows='A'):
+    def __init__(self, shape, x=0, y=0, z=0, rot=0, r=10, spacing=None,
+                 names=('1', 'A')):
         """Creates a rectangular grid of electrodes
 
         Parameters
         ----------
-        cols : int
-            Number of columns in the grid
-        rows : int
-            Number of rows in the grid
-        name_cols, name_rows: {'A', '1'}
-            If 'A', columns will be numbered alphabetically. If '1', columns
-            wil be numbered numerically. Columns and rows may only be strings
-            and integers.
+        shape : (rows, cols)
+            A tuple containing the number of rows x columns in the grid
+        x, y, z : double
+            3D coordinates of the center of the grid
+        rot : double
+            Rotation of the grid in radians (positive angle: counter-clockwise)
+        r : double
+            Electrode radius in microns
+        spacing : double
+            Electrode-to-electrode spacing in microns. If None, 2x radius is
+            chosen.
+        names: (name_rows, name_cols), each of which either 'A' or '1'
+            Naming convention for rows and columns, respectively.
+            If 'A', rows or columns will be labeled alphabetically.
+            If '1', rows or columns will be labeled numerically.
+            Columns and rows may only be strings and integers.
+            For example ('1', 'A') will number rows numerically and columns
+            alphabetically.
 
+        Examples
+        --------
+        # An electrode grid with 2 rows and 4 columns, centered at (10, 20)um,
+        # 500um away from the retinal surface, with names like this:
+        # A1 A2 A3 A4
+        # B1 B2 B3 B4
+        >>> egrid = ElectrodeGrid((2, 4), naming=('A', '1'))
         """
-        self.cols = cols
-        self.rows = rows
+        if not isinstance(shape, (tuple, list, np.ndarray)):
+            raise TypeError("'shape' must be a tuple/list of (rows, cols)")
+        if len(shape) != 2:
+            raise ValueError("'shape' must have two elements: (rows, cols)")
+        if np.prod(shape) <= 0:
+            raise ValueError("Grid must have non-zero rows and columns.")
+        # Extract rows and columns from shape:
+        self.shape = shape
         self.x = x
         self.y = y
         self.z = z
         self.rot = rot
         self.r = r
         self.spacing = spacing
-        self.name_cols = name_cols
-        self.name_rows = name_rows
-        # Instantiate empty collection of electrodes:
+        self.name_rows, self.name_cols = names
+        # Instantiate empty collection of electrodes. This dictionary will be
+        # populated in a private method ``_set_egrid``:
         self.electrodes = coll.OrderedDict()
-        self.set_grid()
+        self._set_grid()
 
     def get_params(self):
         """Return a dictionary of class attributes"""
-        return {'cols': self.cols, 'rows': self.rows,
+        return {'shape': self.shape,
                 'x': self.x, 'y': self.y, 'z': self.z,
                 'rot': self.rot, 'r': self.r, 'spacing': self.spacing,
                 'name_cols': self.name_cols, 'name_rows': self.name_rows}
 
-    def get_x_arr(self):
-        # np.arange(self.cols)
-        x_arr = np.arange(self.cols) * self.spacing - \
-            (self.cols / 2 - 0.5) * self.spacing
-        return x_arr
-
-    # thinking about passing in x_arr because it is modified depending on left/right eye.
-    # It seems like bad style to get it from this method, pass it back in from another class,
-    # and then modify it.
-    def set_grid(self):  # , x_arr):
-        n_elecs = self.cols * self.rows
+    def _set_grid(self):
+        """Private method to build the electrode grid"""
+        n_elecs = np.prod(self.shape)
+        rows, cols = self.shape
 
         # Create electrode names, using either A-Z or 1-n:
         if self.name_cols == '1' and self.name_rows == 'A':
             # Column names should be numbers, row names should be letters:
-            names = [chr(i) + str(j) for i in range(65, 65 + self.rows + 1)
-                     for j in range(1, self.cols + 1)]
-        else:  # TODO jon
+            names = [chr(i) + str(j) for i in range(65, 65 + rows + 1)
+                     for j in range(1, cols + 1)]
+        else:
             if type(self.name_rows) is str:
-                rws = [chr(i) for i in range(65, 65 + self.rows + 1)]
+                rws = [chr(i) for i in range(65, 65 + rows + 1)]
             elif type(self.name_rows) is int:
-                rws = [str(i) for i in range(1, self.cols + 1)]
+                rws = [str(i) for i in range(1, cols + 1)]
             else:
                 raise ValueError("'name_rows' must be a string or integer")
 
             if type(self.name_cols) is str:
-                clms = [chr(i) for i in range(65, 65 + self.rows + 1)]
+                clms = [chr(i) for i in range(65, 65 + rows + 1)]
             elif type(self.name_cols) is int:
-                clms = [str(i) for i in range(1, self.cols + 1)]
+                clms = [str(i) for i in range(1, cols + 1)]
             else:
                 raise ValueError("'name_cols' must be a string or integer")
 
-            names = [rws[i] + clms[j] for i in range(length(rws))
-                     for i in range(length(clms))]
+            names = [rws[i] + clms[j] for i in range(len(rws))
+                     for j in range(len(clms))]
 
         # array containing electrode radii (uniform)
-        r_arr = np.full(shape=self.n_elecs, fill_value=self.r)
+        r_arr = np.full(shape=n_elecs, fill_value=self.r)
 
-        if isinstance(z, (list, np.ndarray)):
-            z_arr = np.asarray(z).flatten()
+        if isinstance(self.z, (list, np.ndarray)):
+            z_arr = np.asarray(self.z).flatten()
             if z_arr.size != len(r_arr):
                 e_s = "If `h` is a list, it must have %d entries." % n_elecs
                 raise ValueError(e_s)
-            else:
-                # All electrodes have the same height
-                z_arr = np.ones_like(r_arr) * self.z
+        else:
+            # All electrodes have the same height
+            z_arr = np.ones_like(r_arr) * self.z
 
-        x_arr = np.arange(self.cols) * self.spacing - \
-            (self.cols / 2 - 0.5) * self.spacing
+        # If spacing is None, choose 2x radius:
+        if self.spacing is None:
+            self.spacing = 2.0 * self.r
+        x_arr = (np.arange(cols) * self.spacing -
+                 (cols / 2 - 0.5) * self.spacing)
 
-        y_arr = np.arange(self.rows) * self.spacing - \
-            (self.rows / 2 - 0.5) * self.spacing
+        y_arr = (np.arange(rows) * self.spacing -
+                 (rows / 2 - 0.5) * self.spacing)
 
+        # Make a 2D meshgrid from the x_arr, y_arr vectors:
         x_arr, y_arr = np.meshgrid(x_arr, y_arr, sparse=False)
+        xy = np.vstack((x_arr.flatten(), y_arr.flatten()))
 
+        # Rotate the grid:
         rotmat = np.array([np.cos(self.rot), -np.sin(self.rot),
                            np.sin(self.rot), np.cos(self.rot)]).reshape((2, 2))
-
-        # Rotate the array
-        xy = np.vstack((x_arr.flatten(), y_arr.flatten()))
         xy = np.matmul(rotmat, xy)
         x_arr = xy[0, :]
         y_arr = xy[1, :]
 
-        # Apply offset
-        x_arr += x
-        y_arr += y
+        # Apply offset to make the grid centered at (self.x, self.y):
+        x_arr += self.x
+        y_arr += self.y
 
-        # maybe parameterize the type of electrode later
+        # TODO parameterize the type of electrode
         for x, y, z, r, name in zip(x_arr, y_arr, z_arr, r_arr, names):
-            self.add_electrode(
-                name, DiskElectrode(self.x, self.y, self.z, self.r))
+            self.add_electrode(name, DiskElectrode(x, y, z, r))

--- a/pulse2percept/implants/base.py
+++ b/pulse2percept/implants/base.py
@@ -298,7 +298,7 @@ class ElectrodeGrid(ElectrodeArray):
         # 500um away from the retinal surface, with names like this:
         # A1 A2 A3 A4
         # B1 B2 B3 B4
-        >>> egrid = ElectrodeGrid((2, 4), naming=('A', '1'))
+        >>> egrid = ElectrodeGrid((2, 4), names=('A', '1'))
         """
         if not isinstance(shape, (tuple, list, np.ndarray)):
             raise TypeError("'shape' must be a tuple/list of (rows, cols)")

--- a/pulse2percept/implants/tests/test_argus.py
+++ b/pulse2percept/implants/tests/test_argus.py
@@ -82,7 +82,6 @@ def test_ArgusI(ztype, x, y, r):
     for eye, el in zip(['LE', 'RE'], ['A1', 'D1']):
         before = implants.ArgusI(eye=eye)
         after = implants.ArgusI(eye=eye, rot=np.deg2rad(10))
-        print(eye, el, after[el].x, before[el].x, after[el].y, before[el].y)
         npt.assert_equal(after[el].x > before[el].x, True)
         npt.assert_equal(after[el].y > before[el].y, True)
 
@@ -148,20 +147,21 @@ def test_ArgusII(ztype, x, y, r):
     argus_re = implants.ArgusII(eye='RE', x=xc, y=yc)
     npt.assert_equal(argus_re['A10'].x > argus_re['A1'].x, True)
     npt.assert_almost_equal(argus_re['A10'].y, argus_re['A1'].y)
-    npt.assert_equal(argus_re.tack[0] < argus_re['A1'].x, True)
-    npt.assert_almost_equal(argus_re.tack[1], yc)
 
     # Left-eye implant:
     argus_le = implants.ArgusII(eye='LE', x=xc, y=yc)
     npt.assert_equal(argus_le['A1'].x > argus_le['A10'].x, True)
     npt.assert_almost_equal(argus_le['A10'].y, argus_le['A1'].y)
-    npt.assert_equal(argus_le.tack[0] > argus_le['A10'].x, True)
-    npt.assert_almost_equal(argus_le.tack[1], yc)
 
     # In both left and right eyes, rotation with positive angle should be
     # counter-clock-wise (CCW): for (x>0,y>0), decreasing x and increasing y
-    for eye, el in zip(['LE', 'RE'], ['F1', 'F10']):
+    for eye, el in zip(['LE', 'RE'], ['F2', 'F10']):
+        # By default, electrode 'F1' in a left eye has the same coordinates as
+        # 'F10' in a right eye (because the columns are reversed). Thus both
+        # cases are testing an electrode with x>0, y>0:
         before = implants.ArgusII(eye=eye)
-        after = implants.ArgusII(eye=eye, rot=np.deg2rad(10))
+        after = implants.ArgusII(eye=eye, rot=np.deg2rad(20))
+        print(after[el].x, before[el].x)
+        print(after[el].y, before[el].y)
         npt.assert_equal(after[el].x < before[el].x, True)
         npt.assert_equal(after[el].y > before[el].y, True)

--- a/pulse2percept/implants/tests/test_base.py
+++ b/pulse2percept/implants/tests/test_base.py
@@ -3,10 +3,12 @@ import collections as coll
 import pytest
 import numpy.testing as npt
 
-from pulse2percept.implants import base
+from pulse2percept.implants import (Electrode, DiskElectrode, PointSource,
+                                    ElectrodeArray, ElectrodeGrid,
+                                    ProsthesisSystem)
 
 
-class ValidElectrode(base.Electrode):
+class ValidElectrode(Electrode):
 
     def electric_potential(self, x, y, z):
         r = np.sqrt((x - self.x) ** 2 + (y - self.y) ** 2 + (z - self.z) ** 2)
@@ -28,7 +30,7 @@ def test_Electrode():
 
 
 def test_PointSource():
-    electrode = base.PointSource(0, 1, 2)
+    electrode = PointSource(0, 1, 2)
     npt.assert_almost_equal(electrode.x, 0)
     npt.assert_almost_equal(electrode.y, 1)
     npt.assert_almost_equal(electrode.z, 2)
@@ -39,14 +41,14 @@ def test_PointSource():
 
 def test_DiskElectrode():
     with pytest.raises(TypeError):
-        base.DiskElectrode(0, 0, 0, [1, 2])
+        DiskElectrode(0, 0, 0, [1, 2])
     with pytest.raises(TypeError):
-        base.DiskElectrode(0, np.array([0, 1]), 0, 1)
+        DiskElectrode(0, np.array([0, 1]), 0, 1)
     # Invalid radius:
     with pytest.raises(ValueError):
-        base.DiskElectrode(0, 0, 0, -5)
+        DiskElectrode(0, 0, 0, -5)
     # Check params:
-    electrode = base.DiskElectrode(0, 1, 2, 100)
+    electrode = DiskElectrode(0, 1, 2, 100)
     npt.assert_almost_equal(electrode.x, 0)
     npt.assert_almost_equal(electrode.y, 1)
     npt.assert_almost_equal(electrode.z, 2)
@@ -69,65 +71,65 @@ def test_DiskElectrode():
 
 def test_ElectrodeArray():
     with pytest.raises(TypeError):
-        base.ElectrodeArray("foo")
+        ElectrodeArray("foo")
     with pytest.raises(TypeError):
-        base.ElectrodeArray(coll.OrderedDict({'A1': 0}))
+        ElectrodeArray(coll.OrderedDict({'A1': 0}))
     with pytest.raises(TypeError):
-        base.ElectrodeArray([0])
+        ElectrodeArray([0])
 
     # Empty array:
-    earray = base.ElectrodeArray([])
+    earray = ElectrodeArray([])
     npt.assert_equal(earray.n_electrodes, 0)
     # npt.assert_equal(earray[0], None)
     npt.assert_equal(earray['A01'], None)
     with pytest.raises(TypeError):
-        earray[base.PointSource(0, 0, 0)]
+        earray[PointSource(0, 0, 0)]
 
     # A single electrode:
-    earray = base.ElectrodeArray(base.PointSource(0, 1, 2))
+    earray = ElectrodeArray(PointSource(0, 1, 2))
     npt.assert_equal(earray.n_electrodes, 1)
-    npt.assert_equal(isinstance(earray[0], base.PointSource), True)
+    npt.assert_equal(isinstance(earray[0], PointSource), True)
     npt.assert_equal(isinstance(earray[[0]], list), True)
-    npt.assert_equal(isinstance(earray[[0]][0], base.PointSource), True)
+    npt.assert_equal(isinstance(earray[[0]][0], PointSource), True)
     npt.assert_almost_equal(earray[0].x, 0)
     npt.assert_almost_equal(earray[0].y, 1)
     npt.assert_almost_equal(earray[0].z, 2)
 
     # Indexing:
-    ps1, ps2 = base.PointSource(0, 0, 0), base.PointSource(1, 1, 1)
-    earray = base.ElectrodeArray({'A01': ps1, 'D07': ps2})
+    ps1, ps2 = PointSource(0, 0, 0), PointSource(1, 1, 1)
+    earray = ElectrodeArray({'A01': ps1, 'D07': ps2})
     npt.assert_equal(earray['A01'], ps1)
     npt.assert_equal(earray['D07'], ps2)
 
 
 def test_ElectrodeArray_add_electrode():
-    earray = base.ElectrodeArray([])
+    earray = ElectrodeArray([])
     npt.assert_equal(earray.n_electrodes, 0)
 
     with pytest.raises(TypeError):
-        earray.add_electrode('A01', base.ElectrodeArray([]))
+        earray.add_electrode('A01', ElectrodeArray([]))
 
     # Add an electrode:
     key0 = 'A04'
-    earray.add_electrode(key0, base.PointSource(0, 1, 2))
+    earray.add_electrode(key0, PointSource(0, 1, 2))
     npt.assert_equal(earray.n_electrodes, 1)
     # Both numeric and string index should work:
     for key in [key0, 0]:
-        npt.assert_equal(isinstance(earray[key], base.PointSource), True)
+        npt.assert_equal(isinstance(earray[key], PointSource), True)
         npt.assert_almost_equal(earray[key].x, 0)
         npt.assert_almost_equal(earray[key].y, 1)
         npt.assert_almost_equal(earray[key].z, 2)
     with pytest.raises(ValueError):
         # Can't add the same electrode twice:
-        earray.add_electrode(key0, base.PointSource(0, 1, 2))
+        earray.add_electrode(key0, PointSource(0, 1, 2))
 
     # Add another electrode:
     key1 = 'A01'
-    earray.add_electrode(key1, base.DiskElectrode(4, 5, 6, 7))
+    earray.add_electrode(key1, DiskElectrode(4, 5, 6, 7))
     npt.assert_equal(earray.n_electrodes, 2)
     # Both numeric and string index should work:
     for key in [key1, 1]:
-        npt.assert_equal(isinstance(earray[key], base.DiskElectrode), True)
+        npt.assert_equal(isinstance(earray[key], DiskElectrode), True)
         npt.assert_almost_equal(earray[key].x, 4)
         npt.assert_almost_equal(earray[key].y, 5)
         npt.assert_almost_equal(earray[key].z, 6)
@@ -137,12 +139,12 @@ def test_ElectrodeArray_add_electrode():
     for keys in [[key0, key1], [0, key1], [key0, 1], [0, 1]]:
         selected = earray[keys]
         npt.assert_equal(isinstance(selected, list), True)
-        npt.assert_equal(isinstance(selected[0], base.PointSource), True)
-        npt.assert_equal(isinstance(selected[1], base.DiskElectrode), True)
+        npt.assert_equal(isinstance(selected[0], PointSource), True)
+        npt.assert_equal(isinstance(selected[1], DiskElectrode), True)
 
 
 def test_ElectrodeArray_add_electrodes():
-    earray = base.ElectrodeArray([])
+    earray = ElectrodeArray([])
     npt.assert_equal(earray.n_electrodes, 0)
 
     with pytest.raises(TypeError):
@@ -155,27 +157,27 @@ def test_ElectrodeArray_add_electrodes():
     key = [0] * 6
     key[0] = 'D03'
     key[1] = 'A02'
-    earray.add_electrodes({key[0]: base.PointSource(0, 1, 2)})
-    earray.add_electrodes({key[1]: base.PointSource(3, 4, 5)})
+    earray.add_electrodes({key[0]: PointSource(0, 1, 2)})
+    earray.add_electrodes({key[1]: PointSource(3, 4, 5)})
     npt.assert_equal(earray[0], earray[key[0]])
     npt.assert_equal(earray[1], earray[key[1]])
     # Can't add the same key twice:
     with pytest.raises(ValueError):
-        earray.add_electrodes({key[0]: base.PointSource(3, 5, 7)})
+        earray.add_electrodes({key[0]: PointSource(3, 5, 7)})
 
     # Add 2 more, now keep order:
     key[2] = 'F10'
     key[3] = 'E12'
-    earray.add_electrodes({key[2]: base.PointSource(6, 7, 8)})
-    earray.add_electrodes({key[3]: base.PointSource(9, 10, 11)})
+    earray.add_electrodes({key[2]: PointSource(6, 7, 8)})
+    earray.add_electrodes({key[3]: PointSource(9, 10, 11)})
     npt.assert_equal(earray[0], earray[key[0]])
     npt.assert_equal(earray[1], earray[key[1]])
     npt.assert_equal(earray[2], earray[key[2]])
     npt.assert_equal(earray[3], earray[key[3]])
 
     # List keeps order:
-    earray.add_electrodes([base.PointSource(12, 13, 14),
-                           base.PointSource(15, 16, 17)])
+    earray.add_electrodes([PointSource(12, 13, 14),
+                           PointSource(15, 16, 17)])
     npt.assert_equal(earray[0], earray[key[0]])
     npt.assert_equal(earray[1], earray[key[1]])
     npt.assert_equal(earray[2], earray[key[2]])
@@ -192,14 +194,14 @@ def test_ElectrodeArray_add_electrodes():
 def test_ProsthesisSystem():
     # Invalid instantiations:
     with pytest.raises(TypeError):
-        base.ProsthesisSystem(base.PointSource(0, 0, 0))
+        ProsthesisSystem(PointSource(0, 0, 0))
     with pytest.raises(ValueError):
-        base.ProsthesisSystem(base.ElectrodeArray(base.PointSource(0, 0, 0)),
-                              eye='both')
+        ProsthesisSystem(ElectrodeArray(PointSource(0, 0, 0)),
+                         eye='both')
 
     # Iterating over the electrode array:
-    earray = base.ElectrodeArray(base.PointSource(0, 0, 0))
-    implant = base.ProsthesisSystem(earray)
+    earray = ElectrodeArray(PointSource(0, 0, 0))
+    implant = ProsthesisSystem(earray)
     npt.assert_equal(implant.n_electrodes, 1)
     npt.assert_equal(implant[0], earray[0])
     npt.assert_equal(implant.keys(), earray.keys())
@@ -219,46 +221,76 @@ def test_ProsthesisSystem():
 
 
 def test_ElectrodeGrid():
-    with pytest.raises(AttributeError):
-        base.ElectrodeGrid.set_grid("badinstantiation")
-    with pytest.raises(AttributeError):
-        base.ElectrodeGrid.set_grid(coll.OrderedDict({'badinstantiation': 0}))
-    with pytest.raises(AttributeError):
-        base.ElectrodeGrid.set_grid([0])
-
-    # naming restrictions
+    # Must pass in tuple/list of (rows, cols) for grid shape:
+    with pytest.raises(TypeError):
+        ElectrodeGrid("badinstantiation")
+    with pytest.raises(TypeError):
+        ElectrodeGrid(coll.OrderedDict({'badinstantiation': 0}))
     with pytest.raises(ValueError):
-        egrid = base.ElectrodeGrid(name_rows=[1])
-
+        ElectrodeGrid([0])
     with pytest.raises(ValueError):
-        egrid.set_grid()
+        ElectrodeGrid([1, 2, 3])
 
-    egrid = base.ElectrodeGrid(name_rows={1})
+    # A valid 2x5 grid centered at (0, 500):
+    shape = (2, 3)
+    x, y = 0, 500
+    spacing = 100
+    egrid = ElectrodeGrid(shape, x=x, y=y, spacing=spacing)
+    npt.assert_equal(egrid.shape, shape)
+    npt.assert_equal(egrid.n_electrodes, np.prod(shape))
+    npt.assert_equal(egrid.x, x)
+    npt.assert_equal(egrid.y, y)
+    npt.assert_almost_equal(egrid.spacing, spacing)
+    # Make sure different electrodes have different coordinates:
+    npt.assert_equal(len(np.unique([e.x for e in egrid.values()])), shape[1])
+    npt.assert_equal(len(np.unique([e.y for e in egrid.values()])), shape[0])
+    # Make sure the average of all x-coordinates == x:
+    # (Note: egrid has all electrodes in a dictionary, with (name, object)
+    # as (key, value) pairs. You can get the electrode names by iterating over
+    # egrid.keys(). You can get the electrode objects by iterating over
+    # egrid.values().)
+    npt.assert_almost_equal(np.mean([e.x for e in egrid.values()]), x)
+    # Same for y:
+    npt.assert_almost_equal(np.mean([e.y for e in egrid.values()]), y)
+
+    # Test whether egrid.z is set correctly, when z is a constant:
+    z = 12
+    # ...
+    # TODO
+    # and when every electrode has a different z:
+    z = np.arange(np.prod(shape))
+    # ...
+    # TODO
+
+    # TODO display a warning when rot > 2pi (meaning it might be in degrees).
+    # I think we did this somewhere in the old Argus code
+
+    # TODO test rotation, making sure positive angles rotate CCW
+
+    # Smallest possible grid:
+    egrid = ElectrodeGrid((1, 1))
+    npt.assert_equal(egrid.shape, (1, 1))
+    npt.assert_equal(egrid.n_electrodes, 1)
+
+    # Can't have a zero-sized grid:
     with pytest.raises(ValueError):
-        egrid.set_grid()
+        egrid = ElectrodeGrid((0, 0))
+    with pytest.raises(ValueError):
+        egrid = ElectrodeGrid((5, 0))
 
-    egrid = base.ElectrodeGrid(name_rows={})
-    with pytest.raises(NameError):
-        egrid.set_grid()
+    # Invalid naming conventions:
+    with pytest.raises(ValueError):
+        egrid = ElectrodeGrid(shape, names=[1])
+    with pytest.raises(ValueError):
+        egrid = ElectrodeGrid(shape, names=[])
+    with pytest.raises(ValueError):
+        egrid = ElectrodeGrid(shape, names={1})
+    with pytest.raises(ValueError):
+        egrid = ElectrodeGrid(shape, names={})
 
-    egrid = base.ElectrodeGrid(name_cols=[])
-    with pytest.raises(NameError):
-        egrid.set_grid()
-
-    # Empty array:
-    #earray = base.ElectrodeArray([])
-    egrid = base.ElectrodeGrid(cols=0, rows=0)
-
-    # not sure if it returns 0
-    npt.assert_equal(egrid.get_x_arr(), 0)
-
-    # inherets electrode array
-    npt.assert_equal(egrid.n_electrodes, 0)
-
-    # A single electrode:
-    #earray = base.ElectrodeArray(base.PointSource(0, 1, 2))
-    # redundant to pass in, just for clarity
-    egrid = base.ElectrodeGrid(cols=1, rows=1)
-    params = egrid.get_params()
-    npt.assert_equal(params["rows"], 1)
-    npt.assert_equal(params["cols"], 1)
+    # Test all naming conventions:
+    egrid = ElectrodeGrid(shape, names=('A', '1'))
+    npt.assert_equal([e for e in egrid.keys()],
+                     ['A1', 'A2', 'A3', 'B1', 'B2', 'B3'])
+    # etc. ... for '1A', '11', 'AA'
+    # TODO

--- a/pulse2percept/viz.py
+++ b/pulse2percept/viz.py
@@ -81,7 +81,7 @@ def plot_fundus(implant, ax=None, loc_od=(15.5, 1.5), n_bundles=100,
         ax.plot(el.x, el.y, 'ow', markersize=np.sqrt(el.r))
 
     # Plot the location of the array's tack and annotate it (optional):
-    if implant.tack:
+    if hasattr(implant, 'tack'):
         tx, ty = implant.tack
         ax.plot(tx, ty, 'ow')
         if annot_array:


### PR DESCRIPTION
Making good progress! I think we're really close.

Just fixed a few minor issues.
- I thought it would make more sense to call `ElectrodeGrid` with a mandatory `shape` parameter.
- `set_egrid` is already called in the constructor, so the user doesn't need to call it. To make that clearer, I changed it to be a private method (name changed to `_set_egrid`).
- I made the tests pass (at least on my machine).
- I also fixed Argus II. Please fix Argus I accordingly.
- There are a few places where I put `TODO` in the code - please have a look at that.


Thanks,
Michael